### PR TITLE
Fixed calculation of memory bandwidth for SAXPY.

### DIFF
--- a/examples/05_saxpy/parallel.cpp
+++ b/examples/05_saxpy/parallel.cpp
@@ -35,9 +35,9 @@ int hpx_main(boost::program_options::variables_map& vm)
             }
         );
     }
-    double elapsed = t.elapsed();
+    double elapsed = t.elapsed() / steps;
 
-    double bandwidth = ((steps * N * sizeof(double)) / elapsed) / 1e6;
+    double bandwidth = ((3 * N * sizeof(double)) / elapsed) / 1e6;
     std::cout << "Bandwidth: " << bandwidth << " MB/s\n";
 
     return hpx::finalize();

--- a/examples/05_saxpy/serial.cpp
+++ b/examples/05_saxpy/serial.cpp
@@ -32,9 +32,9 @@ int hpx_main(boost::program_options::variables_map& vm)
             }
         );
     }
-    double elapsed = t.elapsed();
+    double elapsed = t.elapsed() / steps;
 
-    double bandwidth = ((steps * N * sizeof(double)) / elapsed) / 1e6;
+    double bandwidth = ((3 * N * sizeof(double)) / elapsed) / 1e6;
     std::cout << "Bandwidth: " << bandwidth << " MB/s\n";
 
     return hpx::finalize();


### PR DESCRIPTION
The memory bandwidth was calculated incorrectly by a factor of 3 for the
serial and the parallel version, while the NUMA-aware version used the
correct expression.