### PR TITLE
Replace std::vector with hpx::partitioned_vector

### DIFF
--- a/examples/00_exercises/exercise8.cpp
+++ b/examples/00_exercises/exercise8.cpp
@@ -14,8 +14,8 @@
 
 int main()
 {
-    std::vector<double> v(1000000, 1.0);
-    hpx::reduce(hpx::execution::par, std::begin(v), std::end(v), 0.0,
+    hpx::partitioned_vector<double> v(1000000, 1.0);
+    hpx::reduce(hpx::execution::par, v.begin(), v.end(), 0.0,
         std::plus<double>());
 
     return 0;


### PR DESCRIPTION
This change updates an example to use HPX parallel algorithms and clarifies that it must be built in an HPX-enabled environment .